### PR TITLE
Adding NewResponseBuilder for returning template based response

### DIFF
--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -39,7 +39,7 @@ func LoadConfig(file string) (models.Config, error) {
 	return cfg, err
 }
 
-func NewResponseBuilder(status bool, message string, obj interface{}) (jsoned string, err error) {
+func NewResponseBuilder(w http.ResponseWriter, status bool, message string, obj interface{}) (rw http.ResponseWriter, jsoned string, err error) {
 	stat := "failed"
 	if status {
 		stat = "success"
@@ -53,8 +53,13 @@ func NewResponseBuilder(status bool, message string, obj interface{}) (jsoned st
 		Message: message,
 		Data:    obj,
 	})
+
 	if err != nil {
-		return
+		b = []byte(`{}`)
 	}
-	return string(b), nil
+	jsoned = string(b)
+
+	rw = w
+	rw.Header().Set("Content-Type", "application/json")
+	return
 }

--- a/helpers/helpers.go
+++ b/helpers/helpers.go
@@ -10,6 +10,12 @@ import (
 	"github.com/ndv6/tsaving/models"
 )
 
+type ResponseBuilder struct {
+	Status  string      `json:"status"`
+	Message string      `json:"message"`
+	Data    interface{} `json:"data"`
+}
+
 //untuk ngehandle error"
 func HTTPError(w http.ResponseWriter, status int, errorMessage string) {
 	w.WriteHeader(status)
@@ -31,4 +37,24 @@ func LoadConfig(file string) (models.Config, error) {
 		return models.Config{}, err
 	}
 	return cfg, err
+}
+
+func NewResponseBuilder(status bool, message string, obj interface{}) (jsoned string, err error) {
+	stat := "failed"
+	if status {
+		stat = "success"
+	}
+	if obj == nil {
+		obj = make(map[string]string)
+	}
+
+	b, err := json.Marshal(ResponseBuilder{
+		Status:  stat,
+		Message: message,
+		Data:    obj,
+	})
+	if err != nil {
+		return
+	}
+	return string(b), nil
 }


### PR DESCRIPTION
How to use:
func NewResponseBuilder(ResponseWriter, bool, string, interface{}) (ResponseWriter, string, err)

// to return empty data
w, jsoned, err := helpers.NewResponseBuilder(w, true, "Hello its me", nil)

// to return single object
w, jsoned, err := helpers.NewResponseBuilder(w, true, "Hello its me", models.Customers{
	 	CustId:      1,
	 	AccountNum:  "asd",
	 	Channel:     "web",
	 	CustAddress: "asd",
	 	CustPhone:   "0821",
	 	CustEmail:   "@gmaik",
	 	CustPict:    "/var/example",
	 	IsVerified:  true,
	 	CreatedAt:   time.Now(),
	 	UpdatedAt:   time.Now(),
	 	CustName:    "Sarah",
	})

w, jsoned, err := helpers.NewResponseBuilder(w, true, "Hello its me", []models.Customers{models.Customers{
	 	CustId:      1,
	        AccountNum:  "asd",
	 	Channel:     "web",
	 	CustAddress: "asd",
	 	CustPhone:   "0821",
	 	CustEmail:   "@gmaik",
	 	CustPict:    "/var/example",
	 	IsVerified:  true,
	 	CreatedAt:   time.Now(),
	 	UpdatedAt:   time.Now(),
	 	CustName:    "Sarah",
	 },
	models.Customers{
		CustId:      2,
		AccountNum:  "svacac",
	        Channel:     "sad",
		CustAddress: "svsdmvl",
		CustPhone:   "082113",
		CustEmail:   "@gmaik",
		CustPict:    "/var/example",
		IsVerified:  true,
		CreatedAt:   time.Now(),
		UpdatedAt:   time.Now(),
	 	CustName:    "Murah",
	 	},
	})

// check if error occurs
if err != nil {
helpers.HTTPError(w, http.StatusInternalServerError, constants.CannotEncodeResponse)
return
}

// output for obj = nil
{
    "status": "success",
    "message": "Hello its me",
    "data": {}
}